### PR TITLE
Take into consideration jibri time > than kube time; check for null item

### DIFF
--- a/src/audit.ts
+++ b/src/audit.ts
@@ -115,7 +115,9 @@ export default class Audit {
             if (result[1].length > 0) {
                 items = await this.redisClient.mget(...result[1]);
                 items.forEach((item) => {
-                    audit.push(JSON.parse(item));
+                    if (item) {
+                        audit.push(JSON.parse(item));
+                    }
                 });
             }
         } while (cursor != '0');

--- a/src/instance_group.ts
+++ b/src/instance_group.ts
@@ -130,8 +130,10 @@ export default class InstanceGroupManager {
             if (result[1].length > 0) {
                 items = await this.redisClient.mget(...result[1]);
                 items.forEach((item) => {
-                    const itemJson: InstanceGroup = JSON.parse(item);
-                    instanceGroups.push(itemJson);
+                    if (item) {
+                        const itemJson: InstanceGroup = JSON.parse(item);
+                        instanceGroups.push(itemJson);
+                    }
                 });
             }
         } while (cursor != '0');

--- a/src/instance_tracker.ts
+++ b/src/instance_tracker.ts
@@ -251,11 +251,15 @@ export class InstanceTracker {
             if (result[1].length > 0) {
                 items = await this.redisClient.mget(...result[1]);
                 items.forEach((item) => {
-                    const itemJson = JSON.parse(item);
+                    if (item) {
+                        const itemJson = JSON.parse(item);
 
-                    const periodIdx = Math.floor((currentTime - itemJson.timestamp) / (periodDurationSeconds * 1000));
-                    if (periodIdx < periodsCount) {
-                        metricPoints[periodIdx].push(itemJson);
+                        const periodIdx = Math.floor(
+                            (currentTime - itemJson.timestamp) / (periodDurationSeconds * 1000),
+                        );
+                        if (periodIdx >= 0 && periodIdx < periodsCount) {
+                            metricPoints[periodIdx].push(itemJson);
+                        }
                     }
                 });
             }
@@ -309,7 +313,9 @@ export class InstanceTracker {
             if (result[1].length > 0) {
                 items = await this.redisClient.mget(...result[1]);
                 items.forEach((item) => {
-                    states.push(JSON.parse(item));
+                    if (item) {
+                        states.push(JSON.parse(item));
+                    }
                 });
             }
         } while (cursor != '0');


### PR DESCRIPTION
Fixes "Error processing job AUTOSCALE:18672 for group meet-jit-si-us-phoenix-1-JibriCustomGroup: TypeError: Cannot read property 'push' of undefined" and [QueueProcessor] Error processing job AUTOSCALE:43839 for group meet-jit-si-ap-sydney-1-JibriCustomGroup: TypeError: Cannot read property 'timestamp' of null\"