### PR TITLE
fix: proper errors for instance launch problems

### DIFF
--- a/src/cloud_manager.ts
+++ b/src/cloud_manager.ts
@@ -1,7 +1,7 @@
 import OracleCloudManager from './oracle_instance_manager';
 import OracleInstanceManager from './oracle_instance_manager';
 import { InstanceGroup } from './instance_group';
-import { InstanceTracker, InstanceDetails } from './instance_tracker';
+import { InstanceTracker, InstanceDetails, InstanceState } from './instance_tracker';
 import { Context } from './context';
 import ShutdownManager from './shutdown_manager';
 import Audit from './audit';
@@ -28,6 +28,7 @@ export interface CloudInstance {
 }
 
 export default class CloudManager {
+    private instanceTracker: InstanceTracker;
     private oracleInstanceManager: OracleInstanceManager;
     private shutdownManager: ShutdownManager;
     private audit: Audit;
@@ -39,10 +40,8 @@ export default class CloudManager {
             isDryRun: options.isDryRun,
             ociConfigurationFilePath: options.ociConfigurationFilePath,
             ociConfigurationProfile: options.ociConfigurationProfile,
-            instanceTracker: options.instanceTracker,
-            shutdownManager: options.shutdownManager,
-            audit: options.audit,
         });
+        this.instanceTracker = options.instanceTracker;
         this.shutdownManager = options.shutdownManager;
         this.audit = options.audit;
 
@@ -56,20 +55,53 @@ export default class CloudManager {
         groupCurrentCount: number,
         quantity: number,
         isScaleDownProtected: boolean,
-    ): Promise<boolean> {
+    ): Promise<number> {
         const groupName = group.name;
-        ctx.logger.info('Scaling up', { groupName, quantity });
+        ctx.logger.info('[CloudManager] Scaling up', { groupName, quantity });
         // TODO: get the instance manager by cloud
-        if (group.cloud == 'oracle') {
-            await this.oracleInstanceManager.launchInstances(
-                ctx,
-                group,
-                groupCurrentCount,
-                quantity,
-                isScaleDownProtected,
-            );
+        let scaleUpResult: Array<boolean | string>;
+
+        switch (group.cloud) {
+            case 'oracle':
+                scaleUpResult = await this.oracleInstanceManager.launchInstances(
+                    ctx,
+                    group,
+                    groupCurrentCount,
+                    quantity,
+                );
+                break;
+            default:
+                ctx.logger.error(`Cloud type not supported: ${group.cloud}`);
+                return 0;
         }
-        return true;
+
+        let scaleUpCount = 0;
+        scaleUpResult.forEach(async (instanceId) => {
+            if (instanceId) {
+                scaleUpCount++;
+                if (!this.isDryRun && instanceId !== true) {
+                    await this.audit.saveLaunchEvent(groupName, instanceId);
+                    const state: InstanceState = {
+                        instanceId: instanceId,
+                        instanceType: group.type,
+                        status: {
+                            provisioning: true,
+                        },
+                        timestamp: Date.now(),
+                        metadata: { group: groupName },
+                    };
+                    await this.instanceTracker.track(ctx, state);
+                    if (isScaleDownProtected) {
+                        await this.shutdownManager.setScaleDownProtected(ctx, instanceId, group.protectedTTLSec);
+                        ctx.logger.info(
+                            `[CloudManager] Instance ${instanceId} from group ${groupName} is in protected mode`,
+                        );
+                    }
+                }
+            }
+        });
+
+        return scaleUpCount;
     }
 
     async scaleDown(ctx: Context, group: InstanceGroup, instances: Array<InstanceDetails>): Promise<boolean> {
@@ -80,7 +112,7 @@ export default class CloudManager {
                 return this.shutdownManager.setShutdownStatus(ctx, details);
             }),
         );
-        ctx.logger.info(`Finished scaling down all the instances in group ${group.name}`);
+        ctx.logger.info(`[CloudManager] Finished scaling down all the instances in group ${group.name}`);
         return true;
     }
 

--- a/src/instance_launcher.ts
+++ b/src/instance_launcher.ts
@@ -80,18 +80,42 @@ export default class InstanceLauncher {
                 const actualScaleUpQuantity =
                     Math.min(group.scalingOptions.maxDesired, group.scalingOptions.desiredCount) - count;
                 const scaleDownProtected = await this.instanceGroupManager.isScaleDownProtected(group.name);
-                await this.cloudManager.scaleUp(ctx, group, count, actualScaleUpQuantity, scaleDownProtected);
+                const scaleUpCount = await this.cloudManager.scaleUp(
+                    ctx,
+                    group,
+                    count,
+                    actualScaleUpQuantity,
+                    scaleDownProtected,
+                );
 
-                await this.audit.saveLauncherActionItem(groupName, {
-                    timestamp: Date.now(),
-                    actionType: 'scaleUp',
-                    count: count,
-                    desiredCount: group.scalingOptions.desiredCount,
-                    scaleQuantity: actualScaleUpQuantity,
-                });
+                if (scaleUpCount > 0) {
+                    await this.audit.saveLauncherActionItem(groupName, {
+                        timestamp: Date.now(),
+                        actionType: 'scaleUp',
+                        count: count,
+                        desiredCount: group.scalingOptions.desiredCount,
+                        scaleQuantity: scaleUpCount,
+                    });
 
-                // increment launched instance stats for the group
-                instancesLaunchedCounter.inc({ group: group.name }, actualScaleUpQuantity);
+                    // increment launched instance stats for the group
+                    instancesLaunchedCounter.inc({ group: group.name }, scaleUpCount);
+
+                    // check if scale up count didn't meet requested quantity, error if so
+                    if (scaleUpCount != actualScaleUpQuantity) {
+                        ctx.logger.error(
+                            `[Launcher] Scaling failed to launch requested new instances for group ${groupName} with ${count} instances.`,
+                            { scaleUpRequested: actualScaleUpQuantity, scaleUpActual: scaleUpCount },
+                        );
+                        instanceErrorsCounter.inc({ group: group.name });
+                    }
+                } else {
+                    // something bad happened, so throw an error
+                    ctx.logger.error(
+                        `[Launcher] Scaling failed to launch ANY new instances for group ${groupName} with ${count} instances.`,
+                        { scaleUpQuantity: actualScaleUpQuantity },
+                    );
+                    instanceErrorsCounter.inc({ group: group.name });
+                }
             } else if (count > group.scalingOptions.desiredCount && count > group.scalingOptions.minDesired) {
                 ctx.logger.info('[Launcher] Will scale down to the desired count', { groupName, desiredCount, count });
 

--- a/src/instance_launcher.ts
+++ b/src/instance_launcher.ts
@@ -106,7 +106,6 @@ export default class InstanceLauncher {
                             `[Launcher] Scaling failed to launch requested new instances for group ${groupName} with ${count} instances.`,
                             { scaleUpRequested: actualScaleUpQuantity, scaleUpActual: scaleUpCount },
                         );
-                        instanceErrorsCounter.inc({ group: group.name });
                         throw new Error(
                             `[Launcher] Scaling failed to launch requested new instances for group ${groupName}`,
                         );
@@ -117,7 +116,6 @@ export default class InstanceLauncher {
                         `[Launcher] Scaling failed to launch ANY new instances for group ${groupName} with ${count} instances.`,
                         { scaleUpQuantity: actualScaleUpQuantity },
                     );
-                    instanceErrorsCounter.inc({ group: group.name });
                     throw new Error(`[Launcher] Scaling failed to launch ANY new instances for group ${groupName}`);
                 }
             } else if (count > group.scalingOptions.desiredCount && count > group.scalingOptions.minDesired) {

--- a/src/instance_launcher.ts
+++ b/src/instance_launcher.ts
@@ -107,6 +107,9 @@ export default class InstanceLauncher {
                             { scaleUpRequested: actualScaleUpQuantity, scaleUpActual: scaleUpCount },
                         );
                         instanceErrorsCounter.inc({ group: group.name });
+                        throw new Error(
+                            `[Launcher] Scaling failed to launch requested new instances for group ${groupName}`,
+                        );
                     }
                 } else {
                     // something bad happened, so throw an error
@@ -115,6 +118,7 @@ export default class InstanceLauncher {
                         { scaleUpQuantity: actualScaleUpQuantity },
                     );
                     instanceErrorsCounter.inc({ group: group.name });
+                    throw new Error(`[Launcher] Scaling failed to launch ANY new instances for group ${groupName}`);
                 }
             } else if (count > group.scalingOptions.desiredCount && count > group.scalingOptions.minDesired) {
                 ctx.logger.info('[Launcher] Will scale down to the desired count', { groupName, desiredCount, count });


### PR DESCRIPTION
count instance success when launching
move generic code from oracle instance launcher
handle new instances in cloud manager, not oracle manager
count error when less instances launch than attempted