### PR TITLE
Mark Jibri instances as sidecar running and consider them tracked, if…

### DIFF
--- a/src/group_report.ts
+++ b/src/group_report.ts
@@ -154,6 +154,7 @@ export default class GroupReportGenerator {
             } else {
                 switch (group.type) {
                     case 'jibri':
+                        instanceReport.scaleStatus = 'SIDECAR_RUNNING';
                         if (instanceState.status.jibriStatus && instanceState.status.jibriStatus.busyStatus) {
                             instanceReport.scaleStatus = instanceState.status.jibriStatus.busyStatus.toString();
                         }


### PR DESCRIPTION
… they receive reports without jibriStatus.