### PR TITLE
Remove restriction for frankfurt using only 2 ADs, as E3 instances do…

### DIFF
--- a/src/oracle_instance_manager.ts
+++ b/src/oracle_instance_manager.ts
@@ -149,17 +149,9 @@ export default class OracleInstanceManager {
                 compartmentId: compartmentId,
             },
         );
-        return availabilityDomainsResponse.items
-            .filter((adResponse) => {
-                if (region.toString() == 'eu-frankfurt-1') {
-                    return adResponse.name.endsWith('1') || adResponse.name.endsWith('2');
-                } else {
-                    return true;
-                }
-            })
-            .map((adResponse) => {
-                return adResponse.name;
-            });
+        return availabilityDomainsResponse.items.map((adResponse) => {
+            return adResponse.name;
+        });
     }
 
     private async getFaultDomains(


### PR DESCRIPTION
…n't have this; also restriction seems removed from vm.standard2.4