### PR TITLE
Correctly validate new max, by computing it in validate the same way …

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -47,13 +47,9 @@ export default class Validator {
     async canLaunchInstances(req: Request, count: number): Promise<boolean> {
         const instanceGroup: InstanceGroup = await this.instanceGroupManager.getInstanceGroup(req.params.name);
         // take new maximum into consideration, if set
-        let max = 0;
+        let max;
         if (req.body.maxDesired != null) {
-            if (max > instanceGroup.scalingOptions.maxDesired) {
-                max = req.body.maxDesired;
-            } else {
-                max = instanceGroup.scalingOptions.maxDesired;
-            }
+            max = req.body.maxDesired;
         } else {
             max = instanceGroup.scalingOptions.maxDesired;
         }


### PR DESCRIPTION
…as in launch protected

The initial problem was that if (max > instanceGroup.scalingOptions.maxDesired)  was failing because max was only assigned to 0. That condition should have been if (req.body.maxDesired > instanceGroup.scalingOptions.maxDesired).

Moreover, I updated the validation logic to make sure the new max we are validating against has the same value as the max used in launchProtectedInstanceGroup. Therefore the current validation will not care if the new maxDesired is lower or higher than the old max, will only care if the new maxDesired is correct, meaning new launched instances + current desired <= new maxDesired.