### PR TITLE
untracked instances cause groups to throttle

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -152,6 +152,7 @@ const metricsLoop = new MetricsLoop({
 });
 
 const instanceLauncher = new InstanceLauncher({
+    maxThrottleThreshold: config.MaxThrottleThreshold,
     instanceTracker: instanceTracker,
     cloudManager: cloudManager,
     instanceGroupManager: instanceGroupManager,

--- a/src/app.ts
+++ b/src/app.ts
@@ -143,6 +143,14 @@ const autoscaleProcessor = new AutoscaleProcessor({
     audit: audit,
 });
 
+const metricsLoop = new MetricsLoop({
+    redisClient: redisClient,
+    metricsTTL: config.ServiceLevelMetricsTTL,
+    instanceGroupManager: instanceGroupManager,
+    instanceTracker: instanceTracker,
+    ctx: initCtx,
+});
+
 const instanceLauncher = new InstanceLauncher({
     instanceTracker: instanceTracker,
     cloudManager: cloudManager,
@@ -151,14 +159,7 @@ const instanceLauncher = new InstanceLauncher({
     redisClient,
     shutdownManager,
     audit: audit,
-});
-
-const metricsLoop = new MetricsLoop({
-    redisClient: redisClient,
-    metricsTTL: config.ServiceLevelMetricsTTL,
-    instanceGroupManager: instanceGroupManager,
-    instanceTracker: instanceTracker,
-    ctx: initCtx,
+    metricsLoop,
 });
 
 const groupReportGenerator = new GroupReportGenerator({

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -385,13 +385,4 @@ export default class Audit {
 
         return audit;
     }
-
-    async getGroupUntrackedCount(ctx: Context, groupName: string): Promise<number> {
-        const response = await this.redisClient.get(`service-metrics:${groupName}:untracked-count`);
-        if (response !== null && response.length > 0) {
-            return Number.parseFloat(response) || 0;
-        } else {
-            return 0;
-        }
-    }
 }

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -385,4 +385,13 @@ export default class Audit {
 
         return audit;
     }
+
+    async getGroupUntrackedCount(ctx: Context, groupName: string): Promise<number> {
+        const response = await this.redisClient.get(`service-metrics:${groupName}:untracked-count`);
+        if (response !== null && response.length > 0) {
+            return Number.parseFloat(response) || 0;
+        } else {
+            return 0;
+        }
+    }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ const env = envalid.cleanEnv(process.env, {
     SHUTDOWN_TTL_SEC: envalid.num({ default: 86400 }), // default 1 day
     SHUTDOWN_STATUS_TTL_SEC: envalid.num({ default: 600 }), // default 10 minutes
     AUDIT_TTL_SEC: envalid.num({ default: 172800 }), // default 2 day
+    MAX_THROTTLE_THRESHOLD: envalid.num({ default: 40 }), // default max of 40 untracked per group to throttle scale up
     GROUP_RELATED_DATA_TTL_SEC: envalid.num({ default: 172800 }), // default 2 day; keep group related data max 2 days after the group is deleted or no action is performed on it
     GROUP_LOCK_TTL_MS: envalid.num({ default: 180000 }), // time in ms
     GROUP_JOBS_CREATION_INTERVAL_SEC: envalid.num({ default: 30 }), // with what interval this instance should try producing jobs for group processing
@@ -127,6 +128,8 @@ export default {
     GroupRelatedDataTTL: env.GROUP_RELATED_DATA_TTL_SEC,
     // group processing lock
     GroupLockTTLMs: env.GROUP_LOCK_TTL_MS,
+    // group untracked threshold
+    MaxThrottleThreshold: env.MAX_THROTTLE_THRESHOLD,
     // queue jobs producers
     GroupJobsCreationIntervalSec: env.GROUP_JOBS_CREATION_INTERVAL_SEC,
     SanityJobsCreationIntervalSec: env.SANITY_JOBS_CREATION_INTERVAL_SEC,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -17,6 +17,7 @@ interface InstanceGroupScalingActivitiesRequest {
     enableAutoScale?: boolean;
     enableLaunch?: boolean;
     enableScheduler?: boolean;
+    enableUntrackedThrottle?: boolean;
 }
 
 export interface InstanceGroupDesiredValuesRequest {
@@ -189,6 +190,10 @@ class Handlers {
                 if (scalingActivitiesRequest.enableScheduler != null) {
                     instanceGroup.enableScheduler = scalingActivitiesRequest.enableScheduler;
                 }
+                if (scalingActivitiesRequest.enableUntrackedThrottle != null) {
+                    instanceGroup.enableUntrackedThrottle = scalingActivitiesRequest.enableUntrackedThrottle;
+                }
+
                 await this.instanceGroupManager.upsertInstanceGroup(req.context, instanceGroup);
                 res.status(200);
                 res.send({ save: 'OK' });

--- a/src/instance_group.ts
+++ b/src/instance_group.ts
@@ -25,6 +25,7 @@ export interface InstanceGroup {
     enableAutoScale: boolean;
     enableLaunch: boolean;
     enableScheduler: boolean;
+    enableUntrackedThrottle: boolean;
     gracePeriodTTLSec: number;
     protectedTTLSec: number;
     scalingOptions: ScalingOptions;


### PR DESCRIPTION
flag on groups for throttle behavior on/off
audit adds function for querying untracked by group
instance launcher checks untrack counts