### PR TITLE
Add support for cloud statuses with different cases, e.g. support bot…

### DIFF
--- a/src/cloud_manager.ts
+++ b/src/cloud_manager.ts
@@ -127,7 +127,7 @@ export default class CloudManager {
 
         const instances = await instanceManager.getInstances(ctx, group, cloudRetryStrategy);
         return instances.filter(function (instance) {
-            return instance.cloudStatus !== 'Terminated';
+            return instance.cloudStatus && instance.cloudStatus.toUpperCase() !== 'TERMINATED';
         });
     }
 }

--- a/src/group_report.ts
+++ b/src/group_report.ts
@@ -112,7 +112,7 @@ export default class GroupReportGenerator {
         await this.addShutdownProtectedStatus(ctx, groupReport.instances);
 
         groupReport.instances.forEach((instanceReport) => {
-            if (instanceReport.cloudStatus === 'Provisioning' || instanceReport.cloudStatus === 'Running') {
+            if (this.isProvisioningOrRunningCloudInstance(instanceReport)) {
                 groupReport.cloudCount++;
             }
             if (instanceReport.isShuttingDown) {
@@ -130,10 +130,7 @@ export default class GroupReportGenerator {
             if (instanceReport.reconfigureScheduled) {
                 groupReport.reconfigureScheduledCount++;
             }
-            if (
-                instanceReport.scaleStatus == 'unknown' &&
-                (instanceReport.cloudStatus === 'Provisioning' || instanceReport.cloudStatus === 'Running')
-            ) {
+            if (instanceReport.scaleStatus == 'unknown' && this.isProvisioningOrRunningCloudInstance(instanceReport)) {
                 ctx.logger.info(`Adding untracked instance to group report ${groupName}: ${instanceReport.instanceId}`);
                 groupReport.unTrackedCount++;
             }
@@ -161,6 +158,15 @@ export default class GroupReportGenerator {
         });
 
         return groupReport;
+    }
+
+    private isProvisioningOrRunningCloudInstance(instanceReport: InstanceReport): boolean {
+        return (
+            instanceReport &&
+            instanceReport.cloudStatus &&
+            (instanceReport.cloudStatus.toUpperCase() === 'PROVISIONING' ||
+                instanceReport.cloudStatus.toUpperCase() === 'RUNNING')
+        );
     }
 
     private getInstanceReportsMap(


### PR DESCRIPTION
…h RUNNING and Running cloud statuses

Looks like the oracle API has started returning instances with cloud statuses with different cases: e.g. I can see both  RUNNING and Running being returned by the oracle API. Ingnore the status case when making cloud instances reports (count, untracked etc)