### PR TITLE
feat: sidecar shutdown complete reporting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -340,6 +340,14 @@ app.post('/sidecar/poll', async (req, res, next) => {
     }
 });
 
+app.post('/sidecar/shutdown', async (req, res, next) => {
+    try {
+        await h.sidecarShutdown(req, res);
+    } catch (err) {
+        next(err);
+    }
+});
+
 app.post('/sidecar/stats', async (req, res, next) => {
     try {
         await h.sidecarStats(req, res);

--- a/src/app.ts
+++ b/src/app.ts
@@ -279,6 +279,7 @@ const h = new Handlers({
     instanceTracker,
     instanceGroupManager,
     shutdownManager,
+    cloudManager,
     reconfigureManager,
     groupReportGenerator,
     lockManager,

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -50,6 +50,7 @@ export interface InstanceAuditResponse {
     requestToTerminate: string;
     requestToReconfigure: string;
     reconfigureComplete: string;
+    terminationConfirmation: string;
     latestStatusInfo?: InstanceState;
 }
 
@@ -96,6 +97,7 @@ export default class Audit {
 
         pipeline.expire(`audit:${groupName}:${instanceId}:request-to-launch`, this.auditTTL);
         pipeline.expire(`audit:${groupName}:${instanceId}:request-to-terminate`, this.auditTTL);
+        pipeline.expire(`audit:${groupName}:${instanceId}:confirmation-of-termination`, this.auditTTL);
         pipeline.expire(`audit:${groupName}:${instanceId}:request-to-reconfigure`, this.auditTTL);
         pipeline.expire(`audit:${groupName}:${instanceId}:reconfigure-complete`, this.auditTTL);
 
@@ -325,6 +327,7 @@ export default class Audit {
                 requestToTerminate: 'unknown',
                 requestToReconfigure: 'unknown',
                 reconfigureComplete: 'unknown',
+                terminationConfirmation: 'unknown',
             };
             instanceAuditResponseList.push(instanceAuditResponse);
         });
@@ -339,6 +342,9 @@ export default class Audit {
                         break;
                     case 'request-to-terminate':
                         instanceAuditResponse.requestToTerminate = new Date(instanceAudit.timestamp).toISOString();
+                        break;
+                    case 'confirmation-of-termination':
+                        instanceAuditResponse.terminationConfirmation = new Date(instanceAudit.timestamp).toISOString();
                         break;
                     case 'request-to-reconfigure':
                         instanceAuditResponse.requestToReconfigure = new Date(instanceAudit.timestamp).toISOString();

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -130,6 +130,24 @@ export default class Audit {
         await pipeline.exec();
     }
 
+    async saveShutdownConfirmationEvents(instanceDetails: Array<InstanceDetails>): Promise<void> {
+        const pipeline = this.redisClient.pipeline();
+        for (const instance of instanceDetails) {
+            const value: InstanceAudit = {
+                instanceId: instance.instanceId,
+                type: 'confirmation-of-termination',
+                timestamp: Date.now(),
+            };
+            pipeline.set(
+                `audit:${instance.group}:${instance.instanceId}:confirmation-of-termination`,
+                JSON.stringify(value),
+                'EX',
+                this.auditTTL,
+            );
+        }
+        await pipeline.exec();
+    }
+
     async saveUnsetReconfigureEvents(instanceId: string, group: string): Promise<void> {
         const value: InstanceAudit = {
             instanceId: instanceId,

--- a/src/cloud_manager.ts
+++ b/src/cloud_manager.ts
@@ -114,6 +114,13 @@ export default class CloudManager {
         return true;
     }
 
+    async shutdownInstance(ctx: Context, instance: InstanceDetails): Promise<boolean> {
+        const groupName = instance.group;
+        ctx.logger.info(`[CloudManager] Shutting down instance ${instance.instanceId} from group ${groupName}`);
+        await this.shutdownManager.setShutdownConfirmation(ctx, [instance]);
+        return true;
+    }
+
     async getInstances(
         ctx: Context,
         group: InstanceGroup,

--- a/src/group_report.ts
+++ b/src/group_report.ts
@@ -12,6 +12,7 @@ export interface InstanceReport {
     instanceName?: string;
     scaleStatus?: string;
     cloudStatus?: string;
+    isShutdownComplete?: boolean;
     isShuttingDown?: boolean;
     isScaleDownProtected?: boolean;
     reconfigureScheduled?: string;
@@ -33,6 +34,7 @@ export interface GroupReport {
     expiredCount?: number;
     cloudCount?: number;
     unTrackedCount?: number;
+    shutdownCount?: number;
     shuttingDownCount?: number;
     shutdownErrorCount?: number;
     reconfigureErrorCount?: number;
@@ -118,6 +120,9 @@ export default class GroupReportGenerator {
             if (instanceReport.isShuttingDown) {
                 groupReport.shuttingDownCount++;
             }
+            if (instanceReport.isShutdownComplete) {
+                groupReport.shutdownCount++;
+            }
             if (instanceReport.isScaleDownProtected) {
                 groupReport.scaleDownProtectedCount++;
             }
@@ -186,6 +191,7 @@ export default class GroupReportGenerator {
                 cloudStatus: 'unknown',
                 version: 'unknown',
                 isShuttingDown: instanceState.shutdownStatus,
+                isShutdownComplete: instanceState.shutdownComplete,
                 lastReconfigured: instanceState.lastReconfigured,
                 reconfigureError: instanceState.reconfigureError,
                 shutdownError: instanceState.shutdownError,

--- a/src/group_report.ts
+++ b/src/group_report.ts
@@ -198,7 +198,9 @@ export default class GroupReportGenerator {
                 shutdownError: instanceState.shutdownError,
                 isScaleDownProtected: false,
             };
-            if (instanceState.shutdownStatus) {
+            if (instanceState.shutdownComplete) {
+                instanceReport.scaleStatus = 'SHUTDOWN COMPLETE';
+            } else if (instanceState.shutdownStatus) {
                 instanceReport.scaleStatus = 'SHUTDOWN';
             } else if (instanceState.status.provisioning) {
                 instanceReport.scaleStatus = 'PROVISIONING';

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -114,6 +114,7 @@ class Handlers {
 
     constructor(options: HandlersOptions) {
         this.sidecarPoll = this.sidecarPoll.bind(this);
+        this.sidecarShutdown = this.sidecarShutdown.bind(this);
 
         this.lockManager = options.lockManager;
         this.instanceTracker = options.instanceTracker;
@@ -150,6 +151,26 @@ class Handlers {
         }
     }
 
+    async sidecarShutdown(req: Request, res: Response): Promise<void> {
+        const details: InstanceDetails = req.body;
+        statsCounter.inc();
+        try {
+            await this.shutdownManager.shutdownInstance(req.context, details.instanceId);
+
+            const sendResponse = {
+                save: 'OK',
+            };
+
+            res.status(200);
+            res.send(sendResponse);
+        } catch (err) {
+            req.context.logger.error('Shutdown handling error', { err });
+            statsErrors.inc();
+
+            res.status(500);
+            res.send({ save: 'ERROR' });
+        }
+    }
     async sidecarStats(req: Request, res: Response): Promise<void> {
         const report: StatsReport = req.body;
         statsCounter.inc();

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -117,7 +117,6 @@ class Handlers {
 
     constructor(options: HandlersOptions) {
         this.sidecarPoll = this.sidecarPoll.bind(this);
-        this.sidecarShutdown = this.sidecarShutdown.bind(this);
 
         this.lockManager = options.lockManager;
         this.cloudManager = options.cloudManager;
@@ -157,6 +156,7 @@ class Handlers {
 
     async sidecarShutdown(req: Request, res: Response): Promise<void> {
         const details: InstanceDetails = req.body;
+        req.context.logger.info('Received shutdown confirmation', { details });
         statsCounter.inc();
         try {
             await this.cloudManager.shutdownInstance(req.context, details);

--- a/src/instance_tracker.ts
+++ b/src/instance_tracker.ts
@@ -136,6 +136,7 @@ export interface InstanceState {
     timestamp?: number;
     metadata: InstanceMetadata;
     shutdownStatus?: boolean;
+    shutdownComplete?: string;
     reconfigureError?: boolean;
     shutdownError?: boolean;
     statsError?: boolean;

--- a/src/instance_tracker.ts
+++ b/src/instance_tracker.ts
@@ -673,18 +673,18 @@ export class InstanceTracker {
     }
 
     async filterOutInstancesShuttingDown(ctx: Context, states: Array<InstanceState>): Promise<Array<InstanceState>> {
-        const shutdownStatuses = await this.shutdownManager.getShutdownStatuses(
-            ctx,
-            states.map((state) => {
-                return state.instanceId;
-            }),
-        );
+        const instanceIds = states.map((state) => {
+            return state.instanceId;
+        });
+        const shutdownStatuses = await this.shutdownManager.getShutdownStatuses(ctx, instanceIds);
+
+        const shutdownConfirmations = await this.shutdownManager.getShutdownConfirmations(ctx, instanceIds);
 
         const statesShutdownStatus: boolean[] = [];
         for (let i = 0; i < states.length; i++) {
             statesShutdownStatus.push(this.shutdownStatusFromState(states[i]) || shutdownStatuses[i]);
         }
-        return states.filter((instanceState, index) => !statesShutdownStatus[index]);
+        return states.filter((instanceState, index) => !statesShutdownStatus[index] && !shutdownConfirmations[index]);
     }
 
     mapToInstanceDetails(states: Array<InstanceState>): Array<InstanceDetails> {

--- a/src/shutdown_manager.ts
+++ b/src/shutdown_manager.ts
@@ -111,7 +111,7 @@ export default class ShutdownManager {
         const pipeline = this.redisClient.pipeline();
         for (const instance of instanceDetails) {
             const key = this.shutDownConfirmedKey(instance.instanceId);
-            ctx.logger.debug('Writing shutdown status', { key, status });
+            ctx.logger.debug('Writing shutdown confirmation', { key, status });
             pipeline.set(key, status, 'EX', this.shutdownTTL);
         }
         await pipeline.exec();

--- a/src/shutdown_manager.ts
+++ b/src/shutdown_manager.ts
@@ -73,7 +73,6 @@ export default class ShutdownManager {
         });
         const instances = await pipeline.exec();
         if (instances) {
-            ctx.logger.debug('Read shutdown confirmations', { instances });
             return instances.map((instance: [error: Error | null, result: unknown]) => {
                 if (instance[1] == null) {
                     return false;

--- a/src/test/shutdown_manager.ts
+++ b/src/test/shutdown_manager.ts
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+
+import assert from 'node:assert';
+import test, { afterEach, describe, mock } from 'node:test';
+
+import ShutdownManager from '../shutdown_manager';
+
+describe('ShutdownManager', () => {
+    let context = {
+        logger: {
+            info: mock.fn(),
+            debug: mock.fn(),
+            error: mock.fn(),
+            warn: mock.fn(),
+        },
+    };
+
+    let _keys = [];
+
+    const mockPipeline = {
+        get: mock.fn((key) => _keys.push(key)),
+        set: mock.fn(),
+        exec: mock.fn(() => Promise.resolve(_keys.map(() => [null, null]))),
+    };
+
+    const redisClient = {
+        expire: mock.fn(),
+        zremrangebyscore: mock.fn(() => 0),
+        hgetall: mock.fn(),
+        hset: mock.fn(),
+        hdel: mock.fn(),
+        del: mock.fn(),
+        scan: mock.fn(),
+        zrange: mock.fn(),
+        get: mock.fn(),
+        pipeline: mock.fn(() => mockPipeline),
+    };
+
+    const audit = {
+        log: mock.fn(),
+    };
+
+    const shutdownManager = new ShutdownManager({
+        redisClient,
+        audit,
+        shutdownTTL: 86400,
+    });
+
+    afterEach(() => {
+        _keys = [];
+        mockPipeline.exec.mock.resetCalls();
+        mockPipeline.get.mock.resetCalls();
+        context = {
+            logger: {
+                info: mock.fn(),
+                debug: mock.fn(),
+                error: mock.fn(),
+                warn: mock.fn(),
+            },
+        };
+        mock.restoreAll();
+    });
+
+    // these tests are for the shutdown confirmation statuses
+    describe('shutdownConfirmationStatuses', () => {
+        test('read non-existent shutdown confirmation status', async () => {
+            redisClient.get.mock.mockImplementationOnce(() => null);
+            const result = await shutdownManager.getShutdownConfirmation(context, 'instanceId');
+            console.log(result);
+            assert.equal(result, false, 'expect no shutdown confirmation when no key exists');
+        });
+
+        test('read existing shutdown confirmation status', async () => {
+            const shutdownConfirmation = new Date().toISOString();
+            redisClient.get.mock.mockImplementationOnce(() => shutdownConfirmation);
+            const result = await shutdownManager.getShutdownConfirmation(context, 'instanceId');
+            console.log(result);
+            assert.ok(result, 'expect ok result');
+            assert.equal(result, shutdownConfirmation, 'expect shutdown confirmation to match mock date');
+        });
+
+        test('read multiple non-existent shutdown confirmation statuses', async () => {
+            const instances = ['instanceId', 'instanceId2'];
+            const result = await shutdownManager.getShutdownConfirmations(context, instances);
+            assert.ok(result, 'expect ok result');
+            assert.equal(result.length, instances.length, 'expect confirmation length to match instances length');
+            assert.equal(result[0], false, 'expect first confirmation to be false');
+            assert.equal(result[1], false, 'expect second confirmation to be false');
+        });
+
+        test('read multiple existing shutdown confirmation statuses', async () => {
+            const shutdownConfirmation = new Date().toISOString();
+
+            const instances = ['instanceId', 'instanceId2'];
+            const result = await shutdownManager.getShutdownConfirmations(context, instances);
+            mockPipeline.exec.mock.mockImplementationOnce(() =>
+                Promise.resolve(instances.map(() => [null, shutdownConfirmation])),
+            );
+            assert.ok(result, 'expect ok result');
+            assert.equal(mockPipeline.exec.mock.callCount(), 1, 'expect exec to be called once');
+            assert.equal(
+                mockPipeline.get.mock.callCount(),
+                instances.length,
+                'expect get to be called once per instance',
+            );
+            assert.equal(result.length, instances.length, 'expect confirmation length to match instances length');
+            assert.equal(result[0], shutdownConfirmation, 'expect first confirmation to match mock date');
+            assert.equal(result[1], shutdownConfirmation, 'expect second confirmation to match mock date');
+        });
+    });
+});


### PR DESCRIPTION
This feature should allow sidecars to report final shutdown state, instead of leaving the server to assume draining and shutdown is complete.

It should also leave us free to terminate the instance or otherwise act upon it from the service, instead of requiring instances to be given enough permission to terminate themselves.