### PR TITLE
chore: scope package name to @jitsi/autoscaler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "jitsi-autoscaler",
+  "name": "@jitsi/autoscaler",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "jitsi-autoscaler",
+      "name": "@jitsi/autoscaler",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jitsi-autoscaler",
+  "name": "@jitsi/autoscaler",
   "version": "1.0.0",
   "description": "Implements Autoscaling for Jitsi Services",
   "repository": {


### PR DESCRIPTION
Switches the bare name to the `@jitsi` scope. No functional change.

Note: `ASAP_JWT_AUD=jitsi-autoscaler` in `env.example` happens to share the literal string but is a protocol/issuer constant, not derived from `package.json:name`. Intentionally left unchanged.