### PR TITLE
fix: stop sharing a single mutable OCI region client across concurrent launches

### DIFF
--- a/src/oracle_instance_manager.ts
+++ b/src/oracle_instance_manager.ts
@@ -24,8 +24,13 @@ export interface OracleInstanceManagerOptions {
 export default class OracleInstanceManager implements CloudInstanceManager {
     private isDryRun: boolean;
     private provider: common.ConfigFileAuthenticationDetailsProvider;
-    private identityClient: identity.IdentityClient;
-    private computeManagementClient: core.ComputeManagementClient;
+    // Clients are region-scoped and cached per region rather than shared as a single mutable
+    // instance. The OCI SDK clients carry region as instance state (`.regionId`); mutating a
+    // shared client from concurrent launches/lookups for different regions is a race, since
+    // job processing is concurrent (JOBS_CONCURRENCY > 1) and requests can be sent out under
+    // whichever region happened to be set most recently by an unrelated concurrent call.
+    private identityClientsByRegion: Map<string, identity.IdentityClient> = new Map();
+    private computeManagementClientsByRegion: Map<string, core.ComputeManagementClient> = new Map();
 
     constructor(options: OracleInstanceManagerOptions) {
         this.isDryRun = options.isDryRun;
@@ -33,14 +38,30 @@ export default class OracleInstanceManager implements CloudInstanceManager {
             options.ociConfigurationFilePath,
             options.ociConfigurationProfile,
         );
-        this.identityClient = new identity.IdentityClient({ authenticationDetailsProvider: this.provider });
-        this.computeManagementClient = new core.ComputeManagementClient({
-            authenticationDetailsProvider: this.provider,
-        });
 
         this.launchInstances = this.launchInstances.bind(this);
         this.getAvailabilityDomains = this.getAvailabilityDomains.bind(this);
         this.getFaultDomains = this.getFaultDomains.bind(this);
+    }
+
+    private getIdentityClient(region: string): identity.IdentityClient {
+        let client = this.identityClientsByRegion.get(region);
+        if (!client) {
+            client = new identity.IdentityClient({ authenticationDetailsProvider: this.provider });
+            client.regionId = region;
+            this.identityClientsByRegion.set(region, client);
+        }
+        return client;
+    }
+
+    private getComputeManagementClient(region: string): core.ComputeManagementClient {
+        let client = this.computeManagementClientsByRegion.get(region);
+        if (!client) {
+            client = new core.ComputeManagementClient({ authenticationDetailsProvider: this.provider });
+            client.regionId = region;
+            this.computeManagementClientsByRegion.set(region, client);
+        }
+        return client;
     }
 
     async launchInstances(
@@ -51,7 +72,6 @@ export default class OracleInstanceManager implements CloudInstanceManager {
     ): Promise<Array<string | boolean>> {
         ctx.logger.info(`[oracle] Launching a batch of ${quantity} instances in group ${group.name}`);
 
-        this.computeManagementClient.regionId = group.region;
         const availabilityDomains: string[] = await this.getAvailabilityDomains(group.compartmentId, group.region);
 
         const faultDomainsByAD = await this.getFaultDomainsByAD(group.compartmentId, group.region, availabilityDomains);
@@ -197,7 +217,7 @@ export default class OracleInstanceManager implements CloudInstanceManager {
             return true;
         }
         try {
-            const launchResponse = await this.computeManagementClient.launchInstanceConfiguration({
+            const launchResponse = await this.getComputeManagementClient(group.region).launchInstanceConfiguration({
                 instanceConfigurationId: groupInstanceConfigurationId,
                 instanceConfiguration: overwriteComputeInstanceDetails,
             });
@@ -232,9 +252,8 @@ export default class OracleInstanceManager implements CloudInstanceManager {
 
     //TODO in the future, the list of ADs/FDs per region will be loaded once at startup time
     private async getAvailabilityDomains(compartmentId: string, region: string): Promise<string[]> {
-        this.identityClient.regionId = region;
         const availabilityDomainsResponse: identity.responses.ListAvailabilityDomainsResponse =
-            await this.identityClient.listAvailabilityDomains({
+            await this.getIdentityClient(region).listAvailabilityDomains({
                 compartmentId: compartmentId,
             });
         return availabilityDomainsResponse.items.map((adResponse) => {
@@ -247,12 +266,12 @@ export default class OracleInstanceManager implements CloudInstanceManager {
         region: string,
         availabilityDomain: string,
     ): Promise<string[]> {
-        this.identityClient.regionId = region;
-        const faultDomainsResponse: identity.responses.ListFaultDomainsResponse =
-            await this.identityClient.listFaultDomains({
-                compartmentId: compartmentId,
-                availabilityDomain: availabilityDomain,
-            });
+        const faultDomainsResponse: identity.responses.ListFaultDomainsResponse = await this.getIdentityClient(
+            region,
+        ).listFaultDomains({
+            compartmentId: compartmentId,
+            availabilityDomain: availabilityDomain,
+        });
         return faultDomainsResponse.items.map((fdResponse) => {
             return fdResponse.name;
         });


### PR DESCRIPTION
## Problem

`OracleInstanceManager` holds one `identityClient` and one `computeManagementClient`
per process and sets `.regionId` on them immediately before use instead of scoping
region to the call. That's fine as long as job processing is serialized, but
`#179` raised `JOBS_CONCURRENCY` from an implicit 1 to a default of 5. With
concurrent jobs for different regions now interleaving across `await`s, one
job's `regionId` assignment can get overwritten by another job's before the
actual OCI API call fires.

### Observed impact

During a rollout that launched JVB pools across multiple regions at once, one
region's group never scaled up from 0. Autoscaler logs show its
`launchInstanceConfiguration` calls landing on other regions' API endpoints —
an instance-configuration OCID from one region sent to a different region's
endpoint gets a `500 InternalError` from OCI. Every launch attempt for that
group failed this way; a group only ever succeeds by chance when the shared
client's `regionId` happens to still match at request time.

This is a race that has existed since the client fields were introduced
(2020) — it was just never exercised while the queue processed one job at a
time.

## Fix

Replace the two shared mutable clients with a `Map<region, Client>` cache:
`getIdentityClient(region)` / `getComputeManagementClient(region)` lazily
construct one client per region and reuse it — nothing shared gets mutated by
concurrent calls for different regions anymore.

No behavior change for the common case (a client is still created once and
reused going forward), just scoped per region instead of process-global.

## Testing

- `npx eslint src/oracle_instance_manager.ts --fix` — clean
- `NODE_OPTIONS='--max-old-space-size=8192' npx tsc --noEmit` — clean
- Full suite: `278 passing, 0 failing`
- Not yet verified against live OCI concurrent launches — opening as a draft so a couple people can weigh in before this goes out, given I don't normally operate this service.

## Alternative / stopgap considered

Setting `JOBS_CONCURRENCY=1` on the deployment would also avoid the race
without a code change, but re-serializes *all* job processing (not just
launches) across every group/region. This PR is the targeted fix; happy to
also apply the env override as an immediate mitigation if that's wanted before
this lands.