### PR TITLE
fix: return 401 instead of 500 for malformed JWTs

### DIFF
--- a/src/asap.ts
+++ b/src/asap.ts
@@ -17,6 +17,9 @@ export class ASAPPubKeyFetcher {
     }
 
     async secretCallback(req: Request, token: jwt.Jwt): Promise<jwt.Secret> {
+        if (!token || !token.header) {
+            throw new UnauthorizedError('credentials_bad_format', new Error('token could not be decoded'));
+        }
         if (!token.header.kid) {
             throw new UnauthorizedError('credentials_bad_format', new Error('kid is required in the header'));
         }


### PR DESCRIPTION
## Problem

Requests to protected endpoints (observed on `GET /groups?environment=prod-8x8`) were returning **500 Internal Server Error** when presented with a malformed JWT:

```
internal error TypeError: Cannot read properties of null (reading 'header')
    at ASAPPubKeyFetcher.secretCallback (/usr/src/app/asap.js:18:20)
    at .../express-jwt/dist/index.js:127:46
```

`ASAPPubKeyFetcher.secretCallback` accessed `token.header.kid` before checking that the token was decodable. `express-jwt` passes a **null** `token` to the secret callback when the JWT cannot be decoded (malformed / bad format), so `token.header` threw a raw `TypeError`. That error's name is `TypeError`, not `UnauthorizedError`, so the default error handler fell through to its `500 internal server error` branch instead of treating it as an auth failure.

Net effect: a bad token produced a confusing 500 rather than a clear 401. (Encountered in practice via a hardcoded bad token in a list-groups helper script.)

## Fix

Guard for a null token / missing header in `secretCallback` and throw `UnauthorizedError('credentials_bad_format', ...)`, consistent with the existing missing-`kid` handling right below it. The default error handler already maps `UnauthorizedError` → **401 `invalid token...`**, so no handler change is needed.

```ts
if (!token || !token.header) {
    throw new UnauthorizedError('credentials_bad_format', new Error('token could not be decoded'));
}
if (!token.header.kid) {
    throw new UnauthorizedError('credentials_bad_format', new Error('kid is required in the header'));
}
```

A malformed token on a protected endpoint now returns **401**, not 500. No behavior change for valid tokens.

Note: the adjacent failure mode — the ASAP key server returning a non-2xx when fetching a pubkey — is already handled correctly (`throw new UnauthorizedError('invalid_token', err)` → 401); this PR only closes the null-token gap that produced the 500.

## Testing

- `npx eslint src/asap.ts` — clean
- `NODE_OPTIONS='--max-old-space-size=8192' npx tsc --noEmit` — clean
- `npm test` — **278 passing, 0 failing**
